### PR TITLE
Use taskID instead of taskName to name services

### DIFF
--- a/mesos/register.go
+++ b/mesos/register.go
@@ -104,7 +104,7 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 
 	registered := false
 
-	tname := cleanName(t.Name, m.Separator)
+	tname := cleanName(t.ID, m.Separator)
         log.Debugf("original TaskName : (%v)", tname)
 	if t.Label("overrideTaskName") != "" {
 		tname = cleanName(t.Label("overrideTaskName"), m.Separator)

--- a/mesos/util.go
+++ b/mesos/util.go
@@ -15,8 +15,14 @@ func cleanName(name string, separator string) string {
 		log.Warn(err)
 		return name
 	}
+	id, err_bis := regexp.Compile("\\.[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$")
+	if err_bis != nil {
+		log.Warn(err_bis)
+		return name
+	}
 
-	s := reg.ReplaceAllString(name, "-")
+	without_id := id.ReplaceAllString(name, "")
+	s := reg.ReplaceAllString(without_id, "-")
 
 	return strings.ToLower(strings.Replace(s, "_", separator, -1))
 }


### PR DESCRIPTION
It requires additional cleaning to remove the guid.

This patch will help to solve marathon's issue with folder but is very specific to this use case.
